### PR TITLE
Load time fix

### DIFF
--- a/src/catalysis/datomic.clj
+++ b/src/catalysis/datomic.clj
@@ -52,7 +52,7 @@
 (defn bootstrap
   [db]
   (let [eids (map (fn [[e a v t]] e) (d/datoms db :eavt))]
-    (d/pull-many db '[*] eids)))
+    (d/pull-many db '[*] (distinct eids))))
 
 
 


### PR DESCRIPTION
Fixed the load time problem by removing a bug that was duplicating transaction data 10x, additionally change a couple spots to better utilize default-mappings
